### PR TITLE
マトリクス上に担当者アイコン表示

### DIFF
--- a/app/assets/stylesheets/modules/_matrix.scss
+++ b/app/assets/stylesheets/modules/_matrix.scss
@@ -12,7 +12,7 @@
       .task {
         background-color: $task-color;
         height: 10vh;
-        width: 10vw;
+        width: 12vw;
         border: 1px solid;
         font-size: 2vh;
         a {
@@ -24,6 +24,15 @@
           }
           .content {
             color: $font-color;
+          }
+          .user {
+            color: $font-color;
+            position: relative;
+            &__icon {
+              position: absolute;
+              right: 0.1vw;
+              border-radius: 50px;
+            }
           }
         }
       }

--- a/app/views/modules/_matrix.html.haml
+++ b/app/views/modules/_matrix.html.haml
@@ -8,6 +8,10 @@
               = task.name
             .content
               = "#{task.content[0,5]}..."
+            .user
+              .user__name
+              = "担当者：#{task.user.name[0,5]}..."
+              %img{:src => task.user.image, height: '20', width: '20', class: 'user__icon'}
     .urgency-arrow
       .urgency-arrow__triangle
       .urgency-arrow__square


### PR DESCRIPTION
# WHAT
- トップのマトリクス画面にユーザのアイコンを表示
# WHY
-  タスクの担当ユーザーがわかりやすいようにするため