### PR TITLE
既存タスクと同緊急度&&同重要度のタスクを保存できないようにする

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -34,12 +34,16 @@ class TasksController < ApplicationController
   end
 
   def update
-    task = Task.find(params[:id])
-    task.update(task_params)
-    if task.save
-      redirect_to root_path, notice: 'タスクを更新しました！'
-    else 
-      redirect_to edit_task_path, notice: 'タスクを変更できませんでした。'
+    if Task.where(user_id: current_user.id, importance_id: task_params[:importance_id], urgency_id: task_params[:urgency_id]).exists?
+      redirect_to edit_task_path, notice: '重要度✖️緊急度が同じタスクがすでに存在します。'
+    else
+      task = Task.find(params[:id])
+      task.update(task_params)
+      if task.save
+        redirect_to root_path, notice: 'タスクを更新しました！'
+      else 
+        redirect_to edit_task_path, notice: 'タスクを変更できませんでした。'
+      end
     end
   end
 


### PR DESCRIPTION
# WHAT
- すでに存在する自タスクと同じ緊急度✖️重要度のタスクを作成できないようにバリデーションを設定
# WHY
- 既存タスクにかぶって新規タスクが表示され、タスクを見落とす可能性があるため。
- タスクの優先度が同じだとどちらのタスクからやるべきか明確でなく、本来意図している機能を発揮できなくなるため